### PR TITLE
feature(188): [VOG-361] -> Apply source filters

### DIFF
--- a/\
+++ b/\
@@ -1,0 +1,176 @@
+feat(DataSourceSelect): Change media source names and logos to data types
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch feature/188-vog-361-apply-source-filters
+# Your branch is up to date with 'origin/feature/188-vog-361-apply-source-filters'.
+#
+# Changes to be committed:
+#	modified:   src/components/DataSourceSelect.tsx
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+diff --git a/frontend-nextjs/src/components/DataSourceSelect.tsx b/frontend-nextjs/src/components/DataSourceSelect.tsx
+index d54437c..2cff78c 100644
+--- a/frontend-nextjs/src/components/DataSourceSelect.tsx
++++ b/frontend-nextjs/src/components/DataSourceSelect.tsx
+@@ -1,7 +1,3 @@
+-import derekoFavicon from "@/assets/images/dereko-favicon.png";
+-import geniosFavicon from "@/assets/images/genios-favicon.png";
+-import mediacloudFavicon from "@/assets/images/mediacloud-favicon.png";
+-import nexisFavicon from "@/assets/images/nexis-favicon.png";
+ import { Button } from "@/components/ui/button";
+ import {
+ 	Command,
+@@ -20,17 +16,35 @@ import {
+ 	TooltipProvider,
+ 	TooltipTrigger,
+ } from "@/components/ui/tooltip";
+-import { ChevronsUpDownIcon, InfoIcon, LinkIcon } from "lucide-react";
+-import Image from "next/image";
++import {
++	ChevronsUpDownIcon,
++	GlobeIcon,
++	InfoIcon,
++	LinkIcon,
++	type LucideIcon,
++	NewspaperIcon,
++	SearchIcon,
++} from "lucide-react";
+ import { useMemo, useState } from "react";
+ 
+-const options = [
++type OptionType = {
++	name: string;
++	value: string;
++	Icon: LucideIcon;
++	description: string;
++	links: {
++		label: string;
++		href: string;
++	}[];
++};
++
++const options: OptionType[] = [
+ 	{
+-		name: "Media Cloud",
+-		value: "mediacloud",
+-		image: mediacloudFavicon,
++		name: "Online News",
++		value: "news_online",
++		Icon: GlobeIcon,
+ 		description:
+-			"Global media coverage to understand the content, context, and impact of news stories.",
++			"Online news articles and media from Media Cloud, a global media coverage to understand the content, context, and impact of news stories.",
+ 		links: [
+ 			{
+ 				label: "Official Website",
+@@ -39,11 +53,11 @@ const options = [
+ 		],
+ 	},
+ 	{
+-		name: "Genios",
+-		value: "genios",
+-		image: geniosFavicon,
++		name: "Print News",
++		value: "news_print",
++		Icon: NewspaperIcon,
+ 		description:
+-			"Text-searchable archives of newspapers and other media content for numerous organizations.",
++			"Print news from Genios, text-searchable archives of newspapers and other media content for numerous organizations.",
+ 		links: [
+ 			{
+ 				label: "Official Website",
+@@ -56,11 +70,11 @@ const options = [
+ 		],
+ 	},
+ 	{
+-		name: "Nexis",
+-		value: "nexis",
+-		image: nexisFavicon,
++		name: "Google News",
++		value: "web_google",
++		Icon: SearchIcon,
+ 		description:
+-			"Extensive global news, business, and legal information for research and analytics.",
++			"Extensive global news by Google, business, and legal information for research and analytics.",
+ 		links: [
+ 			{
+ 				label: "Official Website",
+@@ -68,43 +82,29 @@ const options = [
+ 			},
+ 		],
+ 	},
+-	{
+-		name: "DeReKo (Deutsches Referenzkorpus)",
+-		value: "dereko",
+-		image: derekoFavicon,
+-		description:
+-			"Modern German texts, used for linguistic research and analysis.",
+-		links: [
+-			{
+-				label: "Official Website",
+-				href: "https://www.corpusfinder.ugent.be/corpus/69",
+-			},
+-		],
+-	},
+ ];
+ const optionsMap = new Map(options.map((o) => [o.value, o]));
+ 
+ export default function MediaSourceSelect() {
++	const [isOpened, setIsOpened] = useState(false);
+ 	const [selectedId, setSelectedId] = useState<string | null>(options[0].value);
+ 	const selectedValue = useMemo(
+ 		() => (selectedId && optionsMap.get(selectedId)) || undefined,
+ 		[selectedId],
+ 	);
+ 	return (
+-		<Popover>
++		<Popover open={isOpened} onOpenChange={setIsOpened}>
+ 			<PopoverTrigger asChild>
+ 				<Button
+ 					variant="outline"
+ 					role="combobox"
+ 					className="w-fit justify-between"
+ 				>
+-					<div className="flex items-center gap-2">
++					<div className="flex items-center gap-3">
+ 						{selectedValue && (
+-							<Image
+-								src={selectedValue.image}
+-								alt={selectedValue.name}
+-								width={20}
+-								height={20}
++							<selectedValue.Icon
++								size={20}
++								className="mt-0 shrink-0 text-grayDark"
+ 							/>
+ 						)}
+ 						<span>{selectedValue?.name || "Select data source"}</span>
+@@ -126,16 +126,16 @@ export default function MediaSourceSelect() {
+ 								>
+ 									<TooltipProvider>
+ 										<button
+-											className="flex items-start gap-2 text-left grow focusable focus-visible:bg-bg"
++											className="flex items-start gap-3 text-left grow focusable focus-visible:bg-bg"
+ 											type="button"
+-											onClick={() => setSelectedId(option.value)}
++											onClick={() => {
++												setSelectedId(option.value);
++												setIsOpened(false);
++											}}
+ 										>
+-											<Image
+-												src={option.image}
+-												alt={option.name}
+-												width={20}
+-												height={20}
+-												className="mt-0.5"
++											<option.Icon
++												size={20}
++												className="mt-0.5 shrink-0 text-grayDark"
+ 											/>
+ 											<div>
+ 												<div className="font-medium">{option.name}</div>

--- a/frontend-nextjs/src/components/DataSourceSelect.tsx
+++ b/frontend-nextjs/src/components/DataSourceSelect.tsx
@@ -16,6 +16,8 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useFiltersStore } from "@/providers/FiltersStoreProvider";
+import type { MediaSourceType } from "@/stores/filtersStore";
 import {
 	ChevronsUpDownIcon,
 	GlobeIcon,
@@ -29,7 +31,7 @@ import { useMemo, useState } from "react";
 
 type OptionType = {
 	name: string;
-	value: string;
+	value: MediaSourceType;
 	Icon: LucideIcon;
 	description: string;
 	links: {
@@ -86,11 +88,16 @@ const options: OptionType[] = [
 const optionsMap = new Map(options.map((o) => [o.value, o]));
 
 export default function MediaSourceSelect() {
+	const { mediaSource, setMediaSource } = useFiltersStore(
+		({ mediaSource, setMediaSource }) => ({
+			mediaSource,
+			setMediaSource,
+		}),
+	);
 	const [isOpened, setIsOpened] = useState(false);
-	const [selectedId, setSelectedId] = useState<string | null>(options[0].value);
 	const selectedValue = useMemo(
-		() => (selectedId && optionsMap.get(selectedId)) || undefined,
-		[selectedId],
+		() => (mediaSource && optionsMap.get(mediaSource)) || undefined,
+		[mediaSource],
 	);
 	return (
 		<Popover open={isOpened} onOpenChange={setIsOpened}>
@@ -129,7 +136,7 @@ export default function MediaSourceSelect() {
 											className="flex items-start gap-3 text-left grow focusable focus-visible:bg-bg"
 											type="button"
 											onClick={() => {
-												setSelectedId(option.value);
+												setMediaSource(option.value);
 												setIsOpened(false);
 											}}
 										>

--- a/frontend-nextjs/src/components/DataSourceSelect.tsx
+++ b/frontend-nextjs/src/components/DataSourceSelect.tsx
@@ -45,8 +45,7 @@ const options: OptionType[] = [
 		name: "Online News",
 		value: "news_online",
 		Icon: GlobeIcon,
-		description:
-			"Online news articles and media from Media Cloud, a global media coverage to understand the content, context, and impact of news stories.",
+		description: "Global online news articles and media from Media Cloud.",
 		links: [
 			{
 				label: "Official Website",
@@ -58,8 +57,7 @@ const options: OptionType[] = [
 		name: "Print News",
 		value: "news_print",
 		Icon: NewspaperIcon,
-		description:
-			"Print news from Genios, text-searchable archives of newspapers and other media content for numerous organizations.",
+		description: "Archived print news content from Genios for text search.",
 		links: [
 			{
 				label: "Official Website",
@@ -75,12 +73,11 @@ const options: OptionType[] = [
 		name: "Google News",
 		value: "web_google",
 		Icon: SearchIcon,
-		description:
-			"Extensive global news by Google, business, and legal information for research and analytics.",
+		description: "Broad global news from Google for research and analytics.",
 		links: [
 			{
 				label: "Official Website",
-				href: "https://www.lexisnexis.com/en-us/professional/research/nexis.page",
+				href: "https://news.google.com/home",
 			},
 		],
 	},

--- a/frontend-nextjs/src/components/DataSourceSelect.tsx
+++ b/frontend-nextjs/src/components/DataSourceSelect.tsx
@@ -1,7 +1,3 @@
-import derekoFavicon from "@/assets/images/dereko-favicon.png";
-import geniosFavicon from "@/assets/images/genios-favicon.png";
-import mediacloudFavicon from "@/assets/images/mediacloud-favicon.png";
-import nexisFavicon from "@/assets/images/nexis-favicon.png";
 import { Button } from "@/components/ui/button";
 import {
 	Command,
@@ -20,17 +16,35 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ChevronsUpDownIcon, InfoIcon, LinkIcon } from "lucide-react";
-import Image from "next/image";
+import {
+	ChevronsUpDownIcon,
+	GlobeIcon,
+	InfoIcon,
+	LinkIcon,
+	type LucideIcon,
+	NewspaperIcon,
+	SearchIcon,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 
-const options = [
+type OptionType = {
+	name: string;
+	value: string;
+	Icon: LucideIcon;
+	description: string;
+	links: {
+		label: string;
+		href: string;
+	}[];
+};
+
+const options: OptionType[] = [
 	{
-		name: "Media Cloud",
-		value: "mediacloud",
-		image: mediacloudFavicon,
+		name: "Online News",
+		value: "news_online",
+		Icon: GlobeIcon,
 		description:
-			"Global media coverage to understand the content, context, and impact of news stories.",
+			"Online news articles and media from Media Cloud, a global media coverage to understand the content, context, and impact of news stories.",
 		links: [
 			{
 				label: "Official Website",
@@ -39,11 +53,11 @@ const options = [
 		],
 	},
 	{
-		name: "Genios",
-		value: "genios",
-		image: geniosFavicon,
+		name: "Print News",
+		value: "news_print",
+		Icon: NewspaperIcon,
 		description:
-			"Text-searchable archives of newspapers and other media content for numerous organizations.",
+			"Print news from Genios, text-searchable archives of newspapers and other media content for numerous organizations.",
 		links: [
 			{
 				label: "Official Website",
@@ -56,11 +70,11 @@ const options = [
 		],
 	},
 	{
-		name: "Nexis",
-		value: "nexis",
-		image: nexisFavicon,
+		name: "Google News",
+		value: "web_google",
+		Icon: SearchIcon,
 		description:
-			"Extensive global news, business, and legal information for research and analytics.",
+			"Extensive global news by Google, business, and legal information for research and analytics.",
 		links: [
 			{
 				label: "Official Website",
@@ -68,43 +82,29 @@ const options = [
 			},
 		],
 	},
-	{
-		name: "DeReKo (Deutsches Referenzkorpus)",
-		value: "dereko",
-		image: derekoFavicon,
-		description:
-			"Modern German texts, used for linguistic research and analysis.",
-		links: [
-			{
-				label: "Official Website",
-				href: "https://www.corpusfinder.ugent.be/corpus/69",
-			},
-		],
-	},
 ];
 const optionsMap = new Map(options.map((o) => [o.value, o]));
 
 export default function MediaSourceSelect() {
+	const [isOpened, setIsOpened] = useState(false);
 	const [selectedId, setSelectedId] = useState<string | null>(options[0].value);
 	const selectedValue = useMemo(
 		() => (selectedId && optionsMap.get(selectedId)) || undefined,
 		[selectedId],
 	);
 	return (
-		<Popover>
+		<Popover open={isOpened} onOpenChange={setIsOpened}>
 			<PopoverTrigger asChild>
 				<Button
 					variant="outline"
 					role="combobox"
 					className="w-fit justify-between"
 				>
-					<div className="flex items-center gap-2">
+					<div className="flex items-center gap-3">
 						{selectedValue && (
-							<Image
-								src={selectedValue.image}
-								alt={selectedValue.name}
-								width={20}
-								height={20}
+							<selectedValue.Icon
+								size={20}
+								className="mt-0 shrink-0 text-grayDark"
 							/>
 						)}
 						<span>{selectedValue?.name || "Select data source"}</span>
@@ -126,16 +126,16 @@ export default function MediaSourceSelect() {
 								>
 									<TooltipProvider>
 										<button
-											className="flex items-start gap-2 text-left grow focusable focus-visible:bg-bg"
+											className="flex items-start gap-3 text-left grow focusable focus-visible:bg-bg"
 											type="button"
-											onClick={() => setSelectedId(option.value)}
+											onClick={() => {
+												setSelectedId(option.value);
+												setIsOpened(false);
+											}}
 										>
-											<Image
-												src={option.image}
-												alt={option.name}
-												width={20}
-												height={20}
-												className="mt-0.5"
+											<option.Icon
+												size={20}
+												className="mt-0.5 shrink-0 text-grayDark"
 											/>
 											<div>
 												<div className="font-medium">{option.name}</div>

--- a/frontend-nextjs/src/stores/filtersStore.ts
+++ b/frontend-nextjs/src/stores/filtersStore.ts
@@ -20,6 +20,8 @@ import {
 const defaultTo = endOfDay(subDays(new Date(), 1));
 const defaultFrom = startOfDay(subMonths(startOfDay(new Date()), 2));
 
+export type MediaSourceType = "news_online" | "news_print" | "web_google";
+
 export type FiltersState = {
 	from: Date;
 	to: Date;
@@ -29,6 +31,7 @@ export type FiltersState = {
 	toDateString: string;
 	isDefaultTimeRange: boolean;
 	organizers: OrganisationType["name"][];
+	mediaSource: MediaSourceType;
 };
 
 export type FiltersActions = {
@@ -36,6 +39,7 @@ export type FiltersActions = {
 	resetAllFilters: () => void;
 	resetDateRange: () => void;
 	setOrganizers: (organizers: OrganisationType["name"][]) => void;
+	setMediaSource: (mediaSource: MediaSourceType) => void;
 };
 
 export type FiltersStore = FiltersState & FiltersActions;
@@ -49,6 +53,7 @@ export const defaultInitState: FiltersState = {
 	toDateString: format(defaultTo, "yyyy-MM-dd"),
 	isDefaultTimeRange: true,
 	organizers: ["Fridays for Future", "Extinction Rebellion"],
+	mediaSource: "news_online",
 };
 
 const filtersZodSchema = z
@@ -142,6 +147,8 @@ export const createFiltersStore = (
 					})),
 				setOrganizers: (organizers: OrganisationType["name"][]) =>
 					set(() => ({ organizers })),
+				setMediaSource: (mediaSource: MediaSourceType) =>
+					set(() => ({ mediaSource })),
 			}),
 			storageOptions,
 		),

--- a/frontend-nextjs/src/utility/mediaCoverageUtil.ts
+++ b/frontend-nextjs/src/utility/mediaCoverageUtil.ts
@@ -1,3 +1,4 @@
+import type { MediaSourceType } from "@/stores/filtersStore";
 import { format } from "date-fns";
 import { ZodError, z } from "zod";
 import {
@@ -34,11 +35,11 @@ export async function getMediaCoverageData(params?: {
 	from?: Date;
 	to?: Date;
 	organizers: OrganisationType["name"][];
+	mediaSource: MediaSourceType;
 }): Promise<ParsedMediaCoverageType[]> {
 	const json = await fetchApiData({
 		endpoint: "trend",
 		body: {
-			media_source: "news_online",
 			topic: "climate_change",
 			trend_type: "keywords",
 			...(params?.from && params?.to
@@ -51,6 +52,7 @@ export async function getMediaCoverageData(params?: {
 				params?.organizers && params.organizers.length > 0
 					? params.organizers
 					: undefined,
+			media_source: params?.mediaSource || "news_online",
 		},
 		// fallbackFilePathContent: (
 		// 	await import("../data/fallbackMediaCoverage.json")

--- a/frontend-nextjs/src/utility/mediaSentimentImpactUtil.ts
+++ b/frontend-nextjs/src/utility/mediaSentimentImpactUtil.ts
@@ -1,3 +1,4 @@
+import type { MediaSourceType } from "@/stores/filtersStore";
 import { format } from "date-fns";
 import { ZodError, z } from "zod";
 import { fetchApiData } from "./fetchUtil";
@@ -59,6 +60,7 @@ export type MediaSentimentImpactDataType = z.infer<
 
 function getMediaSentimentImpactQuery(params: {
 	organizer: string;
+	mediaSource: MediaSourceType;
 	from?: Date;
 	to?: Date;
 }) {
@@ -80,6 +82,7 @@ function getMediaSentimentImpactQuery(params: {
 
 export async function getMediaSentimentImpactData(params: {
 	organizer: string;
+	mediaSource: MediaSourceType;
 	from?: Date;
 	to?: Date;
 }): Promise<ParsedMediaSentimentImpactType> {

--- a/frontend-nextjs/src/utility/mediaSentimentUtil.ts
+++ b/frontend-nextjs/src/utility/mediaSentimentUtil.ts
@@ -1,3 +1,4 @@
+import type { MediaSourceType } from "@/stores/filtersStore";
 import { format } from "date-fns";
 import { ZodError, z } from "zod";
 import {
@@ -34,9 +35,10 @@ export function getMediaSentimentQuery(params: {
 	from?: Date;
 	to?: Date;
 	organizers: string[];
+	mediaSource: MediaSourceType;
 }) {
 	return {
-		media_source: "news_online",
+		media_source: params.mediaSource || "news_online",
 		topic: "climate_change",
 		trend_type: "sentiment",
 		...(params?.from && params?.to
@@ -56,6 +58,7 @@ export async function getMediaSentimentData(params: {
 	from?: Date;
 	to?: Date;
 	organizers: string[];
+	mediaSource: MediaSourceType;
 }): Promise<MediaDataType> {
 	const json = await fetchApiData({
 		endpoint: "trend",

--- a/frontend-nextjs/src/utility/useKeywords.ts
+++ b/frontend-nextjs/src/utility/useKeywords.ts
@@ -3,17 +3,27 @@ import { useFiltersStore } from "@/providers/FiltersStoreProvider";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, format } from "date-fns";
 import { useEffect, useMemo } from "react";
+import slugify from "slugify";
 import { toast } from "sonner";
 import { getMediaCoverageData } from "./mediaCoverageUtil";
 
 function useMediaCoverageData() {
-	const { from, to, organizers } = useFiltersStore(
-		({ from, to, organizers }) => ({ from, to, organizers }),
+	const { from, to, organizers, mediaSource } = useFiltersStore(
+		({ from, to, organizers, mediaSource }) => ({
+			from,
+			to,
+			organizers,
+			mediaSource,
+		}),
 	);
 	const fromDateString = format(from, "yyyy-MM-dd");
 	const toDateString = format(to, "yyyy-MM-dd");
 	const organizersKey = useMemo(
-		() => organizers.sort().join("-"),
+		() =>
+			organizers
+				.map((o) => slugify(o, { lower: true, strict: true }))
+				.sort()
+				.join("-"),
 		[organizers],
 	);
 	const queryKey = [
@@ -21,10 +31,12 @@ function useMediaCoverageData() {
 		fromDateString,
 		toDateString,
 		organizersKey,
+		mediaSource,
 	];
 	const query = useQuery({
 		queryKey,
-		queryFn: async () => await getMediaCoverageData({ from, to, organizers }),
+		queryFn: async () =>
+			await getMediaCoverageData({ from, to, organizers, mediaSource }),
 		staleTime: endOfDay(new Date()).getTime() - new Date().getTime(),
 	});
 

--- a/frontend-nextjs/src/utility/useMediaSentiment.ts
+++ b/frontend-nextjs/src/utility/useMediaSentiment.ts
@@ -3,17 +3,27 @@ import { useFiltersStore } from "@/providers/FiltersStoreProvider";
 import { useQuery } from "@tanstack/react-query";
 import { endOfDay, format } from "date-fns";
 import { useEffect, useMemo } from "react";
+import slugify from "slugify";
 import { toast } from "sonner";
 import { getMediaSentimentData } from "./mediaSentimentUtil";
 
 function useMediaSentimentData() {
-	const { from, to, organizers } = useFiltersStore(
-		({ from, to, organizers }) => ({ from, to, organizers }),
+	const { from, to, organizers, mediaSource } = useFiltersStore(
+		({ from, to, organizers, mediaSource }) => ({
+			from,
+			to,
+			organizers,
+			mediaSource,
+		}),
 	);
 	const fromDateString = format(from, "yyyy-MM-dd");
 	const toDateString = format(to, "yyyy-MM-dd");
 	const organizersKey = useMemo(
-		() => organizers.sort().join("-"),
+		() =>
+			organizers
+				.map((o) => slugify(o, { lower: true, strict: true }))
+				.sort()
+				.join("-"),
 		[organizers],
 	);
 	const queryKey = [
@@ -21,10 +31,12 @@ function useMediaSentimentData() {
 		fromDateString,
 		toDateString,
 		organizersKey,
+		mediaSource,
 	];
 	const query = useQuery({
 		queryKey,
-		queryFn: async () => await getMediaSentimentData({ from, to, organizers }),
+		queryFn: async () =>
+			await getMediaSentimentData({ from, to, organizers, mediaSource }),
 		staleTime: endOfDay(new Date()).getTime() - new Date().getTime(),
 	});
 	const { error } = query;

--- a/frontend-nextjs/src/utility/useMediaSentimentImpact.ts
+++ b/frontend-nextjs/src/utility/useMediaSentimentImpact.ts
@@ -7,7 +7,9 @@ import { toast } from "sonner";
 import { getMediaSentimentImpactData } from "./mediaSentimentImpactUtil";
 
 function useMediaSentimentImpactData(organizer: string | undefined) {
-	const { from, to } = useFiltersStore(({ from, to }) => ({ from, to }));
+	const { from, to, mediaSource } = useFiltersStore(
+		({ from, to, mediaSource }) => ({ from, to, mediaSource }),
+	);
 	const fromDateString = format(from, "yyyy-MM-dd");
 	const toDateString = format(to, "yyyy-MM-dd");
 	const queryKey = [
@@ -15,12 +17,18 @@ function useMediaSentimentImpactData(organizer: string | undefined) {
 		organizer,
 		fromDateString,
 		toDateString,
+		mediaSource,
 	];
 	const query = useQuery({
 		queryKey,
 		queryFn: async () => {
 			if (organizer === undefined) return undefined;
-			return await getMediaSentimentImpactData({ from, to, organizer });
+			return await getMediaSentimentImpactData({
+				from,
+				to,
+				organizer,
+				mediaSource,
+			});
 		},
 		staleTime: endOfDay(new Date()).getTime() - new Date().getTime(),
 		enabled: organizer !== undefined,


### PR DESCRIPTION
This PR changes the names and descriptions of media sources and applies the selection to the concerned charts.

---

<img width="437" alt="Screenshot 2024-07-04 at 14 24 04" src="https://github.com/SocialChangeLab/media-impact-monitor/assets/2759340/68aedd4c-add3-428b-81db-010237cc0779">

---

These are the new names and contents, @davidpomerenke please review:
```js
[
	{
		name: "Online News",
		value: "news_online",
		Icon: GlobeIcon,
		description: "Global online news articles and media from Media Cloud.",
		links: [
			{
				label: "Official Website",
				href: "https://www.mediacloud.org/",
			},
		],
	},
	{
		name: "Print News",
		value: "news_print",
		Icon: NewspaperIcon,
		description: "Archived print news content from Genios for text search.",
		links: [
			{
				label: "Official Website",
				href: "https://www.genios.de/",
			},
			{
				label: "Press Page",
				href: "https://www.genios.de/browse/Alle/Presse",
			},
		],
	},
	{
		name: "Google News",
		value: "web_google",
		Icon: SearchIcon,
		description: "Broad global news from Google for research and analytics.",
		links: [
			{
				label: "Official Website",
				href: "https://news.google.com/home",
			},
		],
	},
]
```