### PR TITLE
feature(#178): Show percentage of organisation's participants in aggregated bars in protest timeline

### DIFF
--- a/frontend-nextjs/src/components/EventsTimeline/AggregatedEventsTooltip.tsx
+++ b/frontend-nextjs/src/components/EventsTimeline/AggregatedEventsTooltip.tsx
@@ -3,8 +3,11 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/utility/classNames";
-import type { OrganisationType, ParsedEventType } from "@/utility/eventsUtil";
+import {
+	type OrganisationType,
+	type ParsedEventType,
+	compareOrganizationsByColors,
+} from "@/utility/eventsUtil";
 import { format } from "date-fns";
 import { type ReactNode, memo, useMemo } from "react";
 import OrgLine from "./EventTooltipOrgLine";
@@ -46,9 +49,7 @@ function AggregatedEventsTooltip({
 			.sort((a, b) => {
 				if (a.isSelected && !b.isSelected) return -1;
 				if (!a.isSelected && b.isSelected) return 1;
-				if (a.color > b.color) return -1;
-				if (a.color < b.color) return 1;
-				return a.name.localeCompare(b.name);
+				return compareOrganizationsByColors(a, b);
 			});
 	}, [organisations, selectedOrganisations, events]);
 

--- a/frontend-nextjs/src/components/OrgsLegend.tsx
+++ b/frontend-nextjs/src/components/OrgsLegend.tsx
@@ -4,6 +4,20 @@ import { ArrowRight } from "lucide-react";
 import { useMemo } from "react";
 import OrgsLegendItem from "./OrgsLegendItem";
 
+function getOtherOrg(organisations: OrganisationType[]) {
+	return {
+		name: "Other",
+		count: organisations.reduce((acc, org) => acc + org.count, 0),
+		color: `var(--grayDark)`,
+		isMain: false,
+		orgs: organisations.sort((a, b) => {
+			if (a.count > b.count) return -1;
+			if (a.count < b.count) return 1;
+			return a.name.localeCompare(b.name);
+		}),
+	};
+}
+
 function OrgsLegend({
 	organisations,
 }: {
@@ -18,25 +32,20 @@ function OrgsLegend({
 			else mainOrgs.push(org);
 		}
 
+		if (mainOrgs.length === 0) {
+			return {
+				allOrgs: organisations
+					.slice(0, 16)
+					.concat(getOtherOrg(organisations.slice(16))),
+				otherOrgs: organisations.slice(16),
+			};
+		}
 		if (organisations.length < 16) {
 			return { allOrgs: [...mainOrgs, ...otherOrgs], otherOrgs: [] };
 		}
 		if (otherOrgs.length === 0) return { allOrgs: mainOrgs, otherOrgs: [] };
 		return {
-			allOrgs: [
-				...mainOrgs,
-				{
-					name: "Other",
-					count: otherOrgs.reduce((acc, org) => acc + org.count, 0),
-					color: `var(--grayDark)`,
-					isMain: false,
-					orgs: otherOrgs.sort((a, b) => {
-						if (a.count > b.count) return -1;
-						if (a.count < b.count) return 1;
-						return a.name.localeCompare(b.name);
-					}),
-				},
-			],
+			allOrgs: [...mainOrgs, getOtherOrg(otherOrgs)],
 			otherOrgs,
 		};
 	}, [organisations]);

--- a/frontend-nextjs/src/utility/eventsUtil.ts
+++ b/frontend-nextjs/src/utility/eventsUtil.ts
@@ -108,22 +108,22 @@ function validateGetDataResponse(response: unknown): ParsedEventType[] {
 	}
 }
 
-export const distinctiveColors = [
-	`var(--categorical-color-1)`,
-	`var(--categorical-color-2)`,
-	`var(--categorical-color-3)`,
-	`var(--categorical-color-4)`,
-	`var(--categorical-color-5)`,
-	`var(--categorical-color-6)`,
-	`var(--categorical-color-7)`,
-	`var(--categorical-color-8)`,
-	`var(--categorical-color-9)`,
-	`var(--categorical-color-10)`,
-	`var(--categorical-color-11)`,
-	`var(--categorical-color-12)`,
-	"var(--categorical-color-13)",
-	"var(--categorical-color-14)",
-];
+export const distinctiveColorsMap = {
+	"Fridays for Future": `var(--categorical-color-1)`,
+	"Last Generation (Germany)": `var(--categorical-color-2)`,
+	"Extinction Rebellion": `var(--categorical-color-3)`,
+	BUND: `var(--categorical-color-4)`,
+	Greenpeace: `var(--categorical-color-5)`,
+	"Ver.di: United Services Union": `var(--categorical-color-6)`,
+	"Ende Gelaende": `var(--categorical-color-7)`,
+	"The Greens (Germany)": `var(--categorical-color-8)`,
+	"MLPD: Marxist-Leninist Party of Germany": `var(--categorical-color-9)`,
+	"The Left (Germany)": `var(--categorical-color-10)`,
+	"ADFC: German Bicycle Club": `var(--categorical-color-11)`,
+	"SPD: Social Democratic Party of Germany": `var(--categorical-color-12)`,
+	"Government of Germany (2021-)": "var(--categorical-color-13)",
+	"REBELL: Youth League Rebel": "var(--categorical-color-14)",
+};
 
 export function extractEventOrganisations(
 	events: ParsedEventType[],
@@ -151,11 +151,33 @@ export function extractEventOrganisations(
 					isMain: false,
 				};
 			}
-			const color = distinctiveColors[idx];
+			const color =
+				distinctiveColorsMap[
+					organizer.name as keyof typeof distinctiveColorsMap
+				];
 			return {
 				...organizer,
 				color: color ?? "var(--grayDark)",
-				isMain: idx < distinctiveColors.length,
+				isMain: !!color,
 			};
 		});
+}
+
+export function compareOrganizationsByColors(
+	a: OrganisationType,
+	b: OrganisationType,
+): -1 | 0 | 1 {
+	if (a.isMain && !b.isMain) return -1;
+	if (!a.isMain && b.isMain) return 1;
+	if (a.isMain && b.isMain) {
+		const mainNames = Object.keys(distinctiveColorsMap);
+		const aIdx = mainNames.indexOf(a.name);
+		const bIdx = mainNames.indexOf(b.name);
+		if (aIdx > bIdx) return 1;
+		if (aIdx < bIdx) return -1;
+	}
+	const nameComparison = a.name.localeCompare(b.name);
+	if (nameComparison === 1) return 1;
+	if (nameComparison === -1) return -1;
+	return 0;
 }


### PR DESCRIPTION
This PR scales the coloring of aggregate protest timeline bars based on the proportion of participants.

![Screenshot 2024-07-11 at 13 23 51](https://github.com/SocialChangeLab/media-impact-monitor/assets/2759340/6fd6782b-fe84-412a-a296-510b4c23582b)
