### PR TITLE
Bugfix/issue 192/fix fulltext api bug 2

### DIFF
--- a/backend-python/media_impact_monitor/fulltext_coding.py
+++ b/backend-python/media_impact_monitor/fulltext_coding.py
@@ -4,7 +4,7 @@ from litellm import BadRequestError
 
 from media_impact_monitor.util.llm import completion
 
-system_prompt = "You're a sentiment analysis tool. For a given user input, always return the sentiment of the input. Return -1 for negative, 0 for neutral, and 1 for positive. Before you make your decision, reason about the decision."
+system_prompt = """You're a sentiment analysis tool. For a given user input, always return the sentiment of the input. Return -1 for negative, 0 for neutral, and 1 for positive. Before you make your decision, reason about the decision. Stick exactly to the specified JSON schema including the "sentiment_reasoning" and "sentiment" fields."""
 
 tools = [
     {

--- a/backend-python/media_impact_monitor/fulltexts.py
+++ b/backend-python/media_impact_monitor/fulltexts.py
@@ -26,7 +26,9 @@ from media_impact_monitor.util.paths import src
 
 @cache
 def get_fulltexts(q: FulltextSearch) -> pd.DataFrame | None:
-    assert q.topic or q.organizers or q.query or q.event_id
+    assert (
+        q.topic or q.organizers or q.query or q.event_id
+    ), "One of 'topic', 'organizers', 'query', or 'event_id' must be provided."
     keywords = load_keywords()
     num_filters = sum(
         [bool(q.topic), bool(q.organizers), bool(q.query), bool(q.event_id)]
@@ -63,6 +65,10 @@ def get_fulltexts(q: FulltextSearch) -> pd.DataFrame | None:
         query = xs_with_ys(orgs, keywords["activism"], q.media_source)
 
     print(f"Looking for news fulltexts that match: '{query}'")
+
+    assert (
+        q.start_date and q.end_date
+    ), "Both start_date and end_date must be provided; either explicitly or through the event_id."
 
     match q.media_source:
         case "news_online":

--- a/backend-python/media_impact_monitor/fulltexts_test.py
+++ b/backend-python/media_impact_monitor/fulltexts_test.py
@@ -39,9 +39,32 @@ def test_get_fulltexts_for_event():
         assert (texts["date"] <= date(2024, 5, 18)).all()
 
 
-# def test_get_mediacloud_fulltexts():
-#     start_date = date(2024, 5, 20)
-#     query = '"letzte generation"'
-#     fulltexts = get_mediacloud_fulltexts(
-#         query=query, start_date=start_date, countries=["Germany"]
-#     )
+def test_get_fulltexts_with_too_many_params():
+    with pytest.raises(ValueError) as e:
+        get_fulltexts(
+            FulltextSearch(
+                media_source="news_online",
+                topic="climate_change",
+                start_date=date(2023, 1, 1),
+                end_date=date(2024, 1, 31),
+                event_id="adb689988aa3e61021da64570bda6d95",
+            )
+        )
+    assert (
+        str(e.value)
+        == "Only one of 'topic', 'organizers', 'query', 'event_id' is allowed."
+    )
+
+
+def test_get_fulltexts_for_climate_change():
+    texts = get_fulltexts(
+        FulltextSearch(
+            media_source="news_online",
+            topic="climate_change",
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 2),
+        )
+    )
+    assert texts is not None
+    assert len(texts) > 0
+    assert all(date(2023, 1, 1) <= text.date <= date(2023, 1, 2) for text in texts)

--- a/backend-python/media_impact_monitor/types_.py
+++ b/backend-python/media_impact_monitor/types_.py
@@ -157,7 +157,7 @@ class PolicySearch(BaseModel):
 
 class FulltextSearch(BaseModel):
     """
-    You can set parameters for medmedia_source and date_range, and filter by one of the following: topic, organizers, query, or event_id. For now you cannot combine the latter filters, since they all affect the query in different ways.
+    You can set parameters for media_source and date_range, and filter by one of the following: topic, organizers, query, or event_id. For now you cannot combine the latter filters, since they all affect the query in different ways.
     """
 
     media_source: MediaSource = Field(

--- a/backend-python/media_impact_monitor/types_.py
+++ b/backend-python/media_impact_monitor/types_.py
@@ -156,6 +156,10 @@ class PolicySearch(BaseModel):
 
 
 class FulltextSearch(BaseModel):
+    """
+    You can set parameters for medmedia_source and date_range, and filter by one of the following: topic, organizers, query, or event_id. For now you cannot combine the latter filters, since they all affect the query in different ways.
+    """
+
     media_source: MediaSource = Field(
         description="The data source for the media data (i.e., online news, print news, etc.)."
     )


### PR DESCRIPTION
Fixes #193 by adding error messages that either dates or event_id must be provided.
@vogelino Let me know if there is a use case where we do not want to provide dates in the request.
Consistency with the trend endpoint is an argument, but not a very strong one; we have to accept that the API design will not be perfect.

Merge this only after merging https://github.com/SocialChangeLab/media-impact-monitor/pull/201 due to dependency!